### PR TITLE
Release v0.2.1

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,6 +2,7 @@ on:
   pull_request:
     branches:
       - main
+      - test
       - dev
     types:
       - closed
@@ -9,6 +10,10 @@ on:
     branches:
       - dev
   workflow_dispatch:
+    branches:
+      - main
+      - test
+      - dev
 name: 🚀 Deploy website based on branch
 jobs:
   web-deploy:
@@ -31,6 +36,18 @@ jobs:
         password: ${{ secrets.PROD_FTP_PASSWORD }}
         server-dir: /
 
+    - name: 📂 Sync files to TEST
+      if: contains(github.ref, 'refs/heads/test') || (github.event_name == 'pull_request' && contains(github.base_ref, 'test'))
+      uses: SamKirkland/FTP-Deploy-Action@v4.3.5
+      with:
+        server:   ${{ secrets.TEST_FTP_SERVER }}
+        username: ${{ secrets.TEST_FTP_USERNAME }}
+        password: ${{ secrets.TEST_FTP_PASSWORD }}
+        server-dir: /test/
+        exclude: |
+          LICENSE
+          README.md
+
     - name: 📂 Sync files to DEV
       if: contains(github.ref, 'refs/heads/dev')
       uses: SamKirkland/FTP-Deploy-Action@v4.3.5
@@ -38,7 +55,7 @@ jobs:
         server:   ${{ secrets.DEV_FTP_SERVER }}
         username: ${{ secrets.DEV_FTP_USERNAME }}
         password: ${{ secrets.DEV_FTP_PASSWORD }}
-        server-dir: /
+        server-dir: /dev/
         exclude: |
           LICENSE
           README.md

--- a/index.php
+++ b/index.php
@@ -91,14 +91,12 @@ function compareVersions($currentVersion, $latestVersion) {
         case 0:
             return $currentVersion;
         case 1:
-            return "BETA RELEASE $currentVersion INSTALLED";
-        default:
-            return 'Error: Unable to determine version status.';
+            return "BETA-$currentVersion INSTALLED";
     }
 }
 
 // Define the current version constant
-define('CURRENT_VERSION', 'v0.1.3');
+define('CURRENT_VERSION', 'v0.1.4');
 
 // Define variables
 $apiUrl         = 'https://api.github.com/repos/dynamiccookies/Simple-Backup-Utility/releases';
@@ -278,8 +276,13 @@ $random_color = $colors[array_rand($colors)];
             position: fixed;
             bottom: 0;
             right: 0;
-            margin: 20px;
+            margin: 10px;
+            font-size: small;
         }
+		.version-info a {
+			color: yellow;
+			font-weight: bold;
+		}
     </style>
 </head>
 <body>
@@ -321,6 +324,6 @@ $random_color = $colors[array_rand($colors)];
             <?php endforeach; ?>
         </table>
     </div>
-<div class="version-info"><p><?php echo $versionMessage; ?></p></div>
+<div class="version-info"><?php echo $versionMessage; ?></div>
 </body>
 </html>

--- a/index.php
+++ b/index.php
@@ -209,10 +209,10 @@ $random_color = $colors[array_rand($colors)];
             color: #fff;
         }
         table tr:nth-child(even) {
-            background-color: #f0f0f0;
+            background-color: snow;
         }
         table tr:nth-child(odd) {
-            background-color: #e9ecef;
+            background-color: lightgray;
         }
         table th:nth-child(1), table th:nth-child(2),
         table td:nth-child(1), table td:nth-child(2) {
@@ -262,7 +262,7 @@ $random_color = $colors[array_rand($colors)];
                 <th>Delete</th>
             </tr>
             <?php foreach ($backup_folders as $index => $folder): ?>
-                <tr style="background-color: <?php echo $index % 2 == 0 ? '#e9ecef' : '#f0f0f0'; ?>">
+                <tr>
                     <td><?php echo htmlspecialchars($folder['name']); ?></td>
                     <td><?php echo htmlspecialchars($folder['created_date']); ?></td>
                     <td>

--- a/index.php
+++ b/index.php
@@ -170,7 +170,7 @@ $random_color = $colors[array_rand($colors)];
             gap: 10px;
             margin-bottom: 20px;
         }
-        .button-container button {
+        .button-container button, .message {
             box-shadow: 0 8px 8px 1px rgba(0, 0, 0, .2);
             font-weight: bold;
         }

--- a/index.php
+++ b/index.php
@@ -96,7 +96,7 @@ function compareVersions($currentVersion, $latestVersion) {
 }
 
 // Define the current version constant
-define('CURRENT_VERSION', 'v0.1.4');
+define('CURRENT_VERSION', 'v0.1.5');
 
 // Define variables
 $apiUrl         = 'https://api.github.com/repos/dynamiccookies/Simple-Backup-Utility/releases';
@@ -262,6 +262,9 @@ $random_color = $colors[array_rand($colors)];
             border-top: 1px solid #fff;
             margin: 20px 0;
         }
+        .inline-form {
+            display: inline;
+        }
         .trash-icon {
             cursor: pointer;
             background: none;
@@ -284,6 +287,13 @@ $random_color = $colors[array_rand($colors)];
 			font-weight: bold;
 		}
     </style>
+    <script>
+        function confirmDelete(folderName, formId) {
+            if (confirm(`Are you sure you want to delete the folder "${folderName}"?`)) {
+                document.getElementById(formId).submit();
+            }
+        }
+    </script>
 </head>
 <body>
     <div class="container">
@@ -314,8 +324,9 @@ $random_color = $colors[array_rand($colors)];
                     <td><?php echo htmlspecialchars($folder['name']); ?></td>
                     <td><?php echo htmlspecialchars($folder['created_date']); ?></td>
                     <td>
-                        <form method="POST" style="display:inline;">
-                            <button type="submit" name="delete" value="<?php echo htmlspecialchars($folder['name']); ?>" class="trash-icon">
+                        <form method="POST" class="inline-form" id="delete-form-<?php echo $index; ?>">
+                            <input type="hidden" name="delete" value="<?php echo htmlspecialchars($folder['name']); ?>">
+                            <button type="button" class="trash-icon" onclick="confirmDelete('<?php echo htmlspecialchars($folder['name']); ?>', 'delete-form-<?php echo $index; ?>')">
                                 <i class="fa fa-trash"></i>
                             </button>
                         </form>

--- a/index.php
+++ b/index.php
@@ -1,6 +1,43 @@
 <?php
-date_default_timezone_set('America/Chicago'); // Set timezone to CST
+// ****************************************************************************************
+// * Set timezone to CST
+// * Define constant for the current version
+// ****************************************************************************************
+date_default_timezone_set('America/Chicago');
+define('CURRENT_VERSION', 'v0.1.6');
 
+// ****************************************************************************************
+// * Define variables for API URL, directories, and other data
+// ****************************************************************************************
+$apiUrl         = 'https://api.github.com/repos/dynamiccookies/Simple-Backup-Utility/releases';
+$current_dir    = getcwd(); // Get current directory
+$folders        = get_sibling_folders($current_dir); // Get sibling folder names excluding current directory
+$latestVersion  = get_latest_release_tag($apiUrl);
+$message        = '';
+$messageColor   = "#dc3545";
+$versionMessage = compare_versions(CURRENT_VERSION, $latestVersion);
+$backup_folders = get_backup_folders($current_dir);
+$colors         = [
+    "blue", "blueviolet", "brown", "cadetblue", "chocolate", "crimson", "darkblue", 
+    "darkcyan", "darkgray", "darkgreen", "darkmagenta", "darkolivegreen", "darkorchid", 
+    "darkred", "darkslateblue", "darkslategray", "darkviolet", "deeppink", "dimgray", 
+    "firebrick", "forestgreen", "gray", "green", "indianred", "magenta", "maroon", 
+    "mediumblue", "mediumvioletred", "midnightblue", "navy", "orangered", "palevioletred", 
+    "peru", "purple", "rebeccapurple", "red", "seagreen", "sienna", "slategray", "steelblue", 
+    "teal", "tomato"
+];
+$random_color = $colors[array_rand($colors)];
+
+// ****************************************************************************************
+// * Define functions for backup, deletion, and version handling
+// ****************************************************************************************
+/**
+ * Recursively copies files and directories from the source to the destination.
+ *
+ * @param string $source The source directory to back up.
+ * @param string $destination The destination directory where the backup will be stored.
+ * @return int The number of files copied.
+ */
 function backup_folder($source, $destination) {
     if (!is_dir($source)) {
         return 0;
@@ -19,19 +56,53 @@ function backup_folder($source, $destination) {
     return count($files);
 }
 
-function get_sibling_folders($dir) {
-    $parent_dir = dirname($dir);
-    $folders = array_filter(glob($parent_dir . '/*'), 'is_dir');
-    $sibling_folders = [];
-    foreach ($folders as $folder) {
-        $folder_name = basename($folder);
-        if ($folder_name !== basename($dir)) {
-            $sibling_folders[] = $folder_name;
-        }
+/**
+ * Compares the current version with the latest version from GitHub.
+ *
+ * @param string $currentVersion The current version of the utility.
+ * @param string $latestVersion The latest version from GitHub.
+ * @return string A message indicating the version status.
+ */
+function compare_versions($currentVersion, $latestVersion) {
+    // Remove 'v' prefix for comparison
+    $currentVersionClean = ltrim($currentVersion, 'v');
+    $latestVersionClean  = ltrim($latestVersion, 'v');
+    
+    // Compare versions and switch on the result
+    switch (version_compare($currentVersionClean, $latestVersionClean)) {
+        case -1:
+            return "New version <a href='https://github.com/dynamiccookies/Simple-Backup-Utility/releases/tag/$latestVersion' target='_blank'>$latestVersion</a> available!";
+        case 0:
+            return $currentVersion;
+        case 1:
+            return "BETA-$currentVersion INSTALLED";
     }
-    return $sibling_folders;
 }
 
+/**
+ * Recursively deletes a folder and its contents.
+ *
+ * @param string $folder The path of the folder to delete.
+ * @return bool True if the folder was deleted, false otherwise.
+ */
+function delete_backup_folder($folder) {
+    if (!is_dir($folder)) {
+        return false;
+    }
+    $files = array_diff(scandir($folder), array('.', '..'));
+    foreach ($files as $file) {
+        $path = "$folder/$file";
+        is_dir($path) ? delete_backup_folder($path) : unlink($path);
+    }
+    return rmdir($folder);
+}
+
+/**
+ * Retrieves the list of backup folders in the current directory.
+ *
+ * @param string $dir The current directory path.
+ * @return array The list of backup folders with their creation date and timestamp.
+ */
 function get_backup_folders($dir) {
     $folders = array_filter(glob($dir . '/*'), 'is_dir');
     $backup_folders = [];
@@ -53,20 +124,13 @@ function get_backup_folders($dir) {
     return $backup_folders;
 }
 
-function delete_backup_folder($folder) {
-    if (!is_dir($folder)) {
-        return false;
-    }
-    $files = array_diff(scandir($folder), array('.', '..'));
-    foreach ($files as $file) {
-        $path = "$folder/$file";
-        is_dir($path) ? delete_backup_folder($path) : unlink($path);
-    }
-    return rmdir($folder);
-}
-
-// Function to get the latest release tag_name from GitHub
-function getLatestReleaseTag($url) {
+/**
+ * Gets the latest release tag from a GitHub repository.
+ *
+ * @param string $url The GitHub API URL to fetch the releases.
+ * @return string The latest release tag name.
+ */
+function get_latest_release_tag($url) {
     $ch = curl_init();
     curl_setopt($ch, CURLOPT_URL, $url);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
@@ -78,65 +142,79 @@ function getLatestReleaseTag($url) {
     return isset($releases[0]['tag_name']) ? $releases[0]['tag_name'] : '';
 }
 
-// Function to compare versions
-function compareVersions($currentVersion, $latestVersion) {
-    // Remove 'v' prefix for comparison
-    $currentVersionClean = ltrim($currentVersion, 'v');
-    $latestVersionClean  = ltrim($latestVersion, 'v');
-    
-    // Compare versions and switch on the result
-    switch (version_compare($currentVersionClean, $latestVersionClean)) {
-        case -1:
-            return "New version <a href='https://github.com/dynamiccookies/Simple-Backup-Utility/releases/tag/$latestVersion' target='_blank'>$latestVersion</a> available!";
-        case 0:
-            return $currentVersion;
-        case 1:
-            return "BETA-$currentVersion INSTALLED";
+/**
+ * Retrieves the names of sibling directories excluding the current directory.
+ *
+ * @param string $dir The current directory path.
+ * @return array The list of sibling directory names.
+ */
+function get_sibling_folders($dir) {
+    $parent_dir = dirname($dir);
+    $folders = array_filter(glob($parent_dir . '/*'), 'is_dir');
+    $sibling_folders = [];
+    foreach ($folders as $folder) {
+        $folder_name = basename($folder);
+        if ($folder_name !== basename($dir)) {
+            $sibling_folders[] = $folder_name;
+        }
     }
+    return $sibling_folders;
 }
 
-// Define the current version constant
-define('CURRENT_VERSION', 'v0.1.5');
-
-// Define variables
-$apiUrl         = 'https://api.github.com/repos/dynamiccookies/Simple-Backup-Utility/releases';
-$current_dir    = getcwd(); // Get current directory
-$folders        = get_sibling_folders($current_dir); // Get sibling folder names excluding current directory
-$latestVersion  = getLatestReleaseTag($apiUrl);
-$message        = '';
-$messageColor   = "#dc3545";
-$versionMessage = compareVersions(CURRENT_VERSION, $latestVersion);
-
+// ****************************************************************************************
+// * Handle POST requests for folder deletion and backup creation
+// ****************************************************************************************
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    // Check if a delete action is requested
     if (isset($_POST['delete'])) {
+        // Construct the path to the folder to delete
         $folder_to_delete = $current_dir . '/' . $_POST['delete'];
+        
+        // Attempt to delete the folder
         if (delete_backup_folder($folder_to_delete)) {
+            // Set success message if deletion is successful
             $message = "The folder '{$_POST['delete']}' has been deleted.";
-            $messageColor = "#28a745";
+            $messageColor = "#28a745"; // Green color for success message
         } else {
+            // Set error message if deletion fails
             $message = "Failed to delete the folder '{$_POST['delete']}'.";
         }
+    // Process backup creation if 'delete' action is not requested
     } else {
+        
+        // Sanitize and prepare the backup folder name
         $input_name = preg_replace('/\s+/', '-', trim($_POST['folder_name'])); // Replace spaces with dashes
         
+        // Check if a valid backup folder is selected
         if (isset($_POST['backup']) && in_array($_POST['backup'], $folders)) {
+            // Define the source path for backup
             $source = "../{$_POST['backup']}";
         } else {
+            // Set error message for invalid backup folder selection
             $message = 'Invalid backup folder selected.';
         }
 
+        // Proceed if no error message is set
         if (empty($message)) {
+            // Define the destination folder name and path
             $folder_name = $_POST['backup'] . '_' . $input_name;
             $destination = "../" . basename($current_dir) . "/" . $folder_name;
 
+            // Check if the destination folder already exists
             if (is_dir($destination)) {
+                // Set error message if the destination folder already exists
                 $message = "The folder '$folder_name' already exists. Backup cannot be completed.";
             } else {
+                // Perform the backup operation
                 $file_count = backup_folder($source, $destination);
+                
+                // Check if files are successfully backed up
                 if ($file_count > 0) {
+                    // Set success message if backup operation is successful
                     $message = "The folder '$folder_name' has been created with $file_count files.";
-                    $messageColor = "#28a745";
+                    $messageColor = "#28a745"; // Green color for success message
                 } else {
+                    // Set error message if backup operation fails
                     $message = "Failed to create the folder '$folder_name'.";
                 }
             }
@@ -144,21 +222,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 }
 
-$backup_folders = get_backup_folders($current_dir);
-
-// Array of colors
-$colors = [
-    "blue", "blueviolet", "brown", "cadetblue", "chocolate", "crimson", "darkblue", 
-    "darkcyan", "darkgray", "darkgreen", "darkmagenta", "darkolivegreen", "darkorchid", 
-    "darkred", "darkslateblue", "darkslategray", "darkviolet", "deeppink", "dimgray", 
-    "firebrick", "forestgreen", "gray", "green", "indianred", "magenta", "maroon", 
-    "mediumblue", "mediumvioletred", "midnightblue", "navy", "orangered", "palevioletred", 
-    "peru", "purple", "rebeccapurple", "red", "seagreen", "sienna", "slategray", "steelblue", 
-    "teal", "tomato"
-];
-
-// Randomly select a color
-$random_color = $colors[array_rand($colors)];
 ?>
 
 <!DOCTYPE html>
@@ -288,6 +351,7 @@ $random_color = $colors[array_rand($colors)];
 		}
     </style>
     <script>
+	    // Function to confirm folder deletion and submit the form
         function confirmDelete(folderName, formId) {
             if (confirm(`Are you sure you want to delete the folder "${folderName}"?`)) {
                 document.getElementById(formId).submit();
@@ -298,6 +362,8 @@ $random_color = $colors[array_rand($colors)];
 <body>
     <div class="container">
         <h1>Backup Utility</h1>
+
+        <!-- Backup form for creating new backups -->
         <form method="POST">
             <input type="text" id="folder_name" name="folder_name" placeholder="Backup Name" required>
             <div class="button-container">
@@ -306,13 +372,20 @@ $random_color = $colors[array_rand($colors)];
                 <?php endforeach; ?>
             </div>
         </form>
+
+        <!-- Display message if there is any -->
         <?php if ($message): ?>
             <div class="message">
                 <?php echo htmlspecialchars($message); ?>
             </div>
         <?php endif; ?>
-        <div class="divider"></div> <!-- Horizontal divider line -->
+
+        <!-- Horizontal divider line -->
+        <div class="divider"></div>
+
         <h2>Existing Backups</h2>
+
+        <!-- Table displaying existing backups -->
         <table>
             <tr>
                 <th>Backup</th>
@@ -324,10 +397,11 @@ $random_color = $colors[array_rand($colors)];
                     <td><?php echo htmlspecialchars($folder['name']); ?></td>
                     <td><?php echo htmlspecialchars($folder['created_date']); ?></td>
                     <td>
+                        <!-- Form for deleting a backup folder -->
                         <form method="POST" class="inline-form" id="delete-form-<?php echo $index; ?>">
                             <input type="hidden" name="delete" value="<?php echo htmlspecialchars($folder['name']); ?>">
                             <button type="button" class="trash-icon" onclick="confirmDelete('<?php echo htmlspecialchars($folder['name']); ?>', 'delete-form-<?php echo $index; ?>')">
-                                <i class="fa fa-trash"></i>
+                                <i class="fa fa-trash"></i> <!-- Trash icon for delete button -->
                             </button>
                         </form>
                     </td>
@@ -335,6 +409,9 @@ $random_color = $colors[array_rand($colors)];
             <?php endforeach; ?>
         </table>
     </div>
-<div class="version-info"><?php echo $versionMessage; ?></div>
+
+    <!-- Display version information at the bottom right corner -->
+    <div class="version-info"><?php echo $versionMessage; ?></div>
 </body>
+
 </html>

--- a/index.php
+++ b/index.php
@@ -4,7 +4,7 @@
 // * Define constant for the current version
 // ****************************************************************************************
 date_default_timezone_set('America/Chicago');
-define('CURRENT_VERSION', 'v0.2.0');
+define('CURRENT_VERSION', 'v0.2.1');
 
 // ****************************************************************************************
 // * Define variables for API URL, directories, and other data
@@ -16,7 +16,6 @@ $latestVersion  = get_latest_release_tag($apiUrl);
 $message        = '';
 $messageColor   = "#dc3545";
 $versionMessage = compare_versions(CURRENT_VERSION, $latestVersion);
-$backup_folders = get_backup_folders($current_dir);
 $colors         = [
     "blue", "blueviolet", "brown", "cadetblue", "chocolate", "crimson", "darkblue", 
     "darkcyan", "darkgray", "darkgreen", "darkmagenta", "darkolivegreen", "darkorchid", 
@@ -422,7 +421,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 <th>Created Date (CST)</th>
                 <th>Delete</th>
             </tr>
-            <?php foreach ($backup_folders as $index => $folder): ?>
+            <?php 
+                $backup_folders = get_backup_folders($current_dir);
+                foreach ($backup_folders as $index => $folder): ?>
                 <tr>
                     <td><?php echo htmlspecialchars($folder['name']); ?></td>
                     <td><?php echo htmlspecialchars($folder['created_date']); ?></td>

--- a/index.php
+++ b/index.php
@@ -4,7 +4,7 @@
 // * Define constant for the current version
 // ****************************************************************************************
 date_default_timezone_set('America/Chicago');
-define('CURRENT_VERSION', 'v0.1.6');
+define('CURRENT_VERSION', 'v0.2.0');
 
 // ****************************************************************************************
 // * Define variables for API URL, directories, and other data

--- a/index.php
+++ b/index.php
@@ -183,9 +183,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     // Process backup creation if 'delete' action is not requested
     } else {
         
-        // Sanitize and prepare the backup folder name
-        $input_name = preg_replace('/\s+/', '-', trim($_POST['folder_name'])); // Replace spaces with dashes
-        
         // Check if a valid backup folder is selected
         if (isset($_POST['backup']) && in_array($_POST['backup'], $folders)) {
             // Define the source path for backup
@@ -199,7 +196,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         if (empty($message)) {
 
             // Define the destination folder name and path
-            $folder_name = $_POST['backup'] . '_' . $input_name;
+            $folder_name = $_POST['backup'] . '_' . preg_replace('/\s+/', '-', trim($_POST['folder_name']));
             $destination = "../" . basename($current_dir) . "/" . $folder_name;
 
             // Check if the destination folder already exists

--- a/index.php
+++ b/index.php
@@ -165,6 +165,7 @@ function get_sibling_folders($dir) {
 // * Handle POST requests for folder deletion and backup creation
 // ****************************************************************************************
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+
     // Check if a delete action is requested
     if (isset($_POST['delete'])) {
         // Construct the path to the folder to delete
@@ -196,6 +197,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
         // Proceed if no error message is set
         if (empty($message)) {
+
             // Define the destination folder name and path
             $folder_name = $_POST['backup'] . '_' . $input_name;
             $destination = "../" . basename($current_dir) . "/" . $folder_name;
@@ -345,13 +347,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             margin: 10px;
             font-size: small;
         }
-		.version-info a {
-			color: yellow;
-			font-weight: bold;
-		}
+        .version-info a {
+            color: yellow;
+            font-weight: bold;
+        }
     </style>
     <script>
-	    // Function to confirm folder deletion and submit the form
+        // Function to confirm folder deletion and submit the form
         function confirmDelete(folderName, formId) {
             if (confirm(`Are you sure you want to delete the folder "${folderName}"?`)) {
                 document.getElementById(formId).submit();


### PR DESCRIPTION
### New Features ✨

- 4c55f27 Update message container formatting [ #9 ]

- 196d660 Added version number and check for updates [ #5 ]
  - Added current version number to the bottom corner of the page.
  - Added feature to auto-compare the current version to the latest release and display message if different.

- 067d3e5 Add confirmation when deleting a backup [ #7 ]
  - Added a JavaScript function to prompt with confirmation when deleting a backup.

- b8351e2 Add test deployment
  - Added test deployment and updated workflow_dispatch to specify branches.

- d369a36 Add clickable update feature [ #15 ]
  - Added "(Update Now)" text to New Version message with link to update.
  - Added JavaScript triggerUpdate() function to submit POST request method.
  - Updated isset($_POST) section to add elseif (isset($_POST['update']) section.
  - Replaced else{} section with elseif (isset($_POST['backup']).
  - Added else{} as catchall.
  - Incremented version to v0.2.0.

### Fixes 🛠️

- 2536d27 Fix table alternating row background colors [ #1 ]
  - Fixed issue with table row background colors not alternating properly.

- d6adf3d Update version message text and formatting
  - Updated the version message BETA text and removed the unnecessary default text.
  - Removed unnecessary paragraph HTML tags.
  - Updated the message CSS to decrease the margin, decrease the text size, and color and bold the version number when linked to the repo.

- acfd5ce Update commenting [ #18 ]
  - Moved PHP variable declarations to the top of the script.
  - Rearranged the PHP functions to be in alphabetical order.
  - Added extensive commenting.

- 61d8403 Update line spacing and tabs
  - Replace tabs with four spaces and add a couple lines for better spacing.

- 680abf9 Remove unnecessary $input_name variable
  - Consolidated $input_name variable as it was only used in one place.

- 0635ca8 Fixed Existing Backups table not updating [ #22 ]
  - Issue was created in acfd5ce when the line that sets the `$backup_folders` variable was moved to before the backup folder is created/deleted.
  - Fixed by moving it to just before where it's used.
  - Incremented version to v0.2.1.

### Known Bugs 🐛

- #11 
- #21 
- #25 

