### PR TITLE
Release v1.1.2

### DIFF
--- a/index.php
+++ b/index.php
@@ -534,13 +534,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             }
         });
 
-        // Hide message after 10 seconds
+        // Show message for 10 seconds
         setTimeout(function() {
             var messageDiv = document.getElementById('message');
             if (messageDiv) {
                 messageDiv.classList.add('fade-out');
 
-                // Hide message container after 2 seconds
+                // Hide message container after 2 second fade out
                 setTimeout(function() {
                     messageDiv.style.display = 'none';
                 }, 2000);

--- a/index.php
+++ b/index.php
@@ -1,14 +1,17 @@
 <?php
 
-// ****************************************************************************************
-// * Set timezone to CST
-// * Define constant for the current version
-// ****************************************************************************************
+/**
+ * Define constant for the current version
+ */
+
 define('CURRENT_VERSION', 'v1.0.0');
 
-// ****************************************************************************************
-// * Define variables for API URL, directories, and other data
-// ****************************************************************************************
+/******************************************************************************/
+
+/**
+ * Define variables for API URL, directories, and other data
+ */
+
 $api_url         = 'https://api.github.com/repos/dynamiccookies/Simple-Backup-Utility/releases';
 $colors          = [
     'blue', 'blueviolet', 'brown', 'cadetblue', 'chocolate', 'crimson', 'darkblue', 
@@ -19,25 +22,29 @@ $colors          = [
     'peru', 'purple', 'rebeccapurple', 'red', 'seagreen', 'sienna', 'slategray', 'steelblue', 
     'teal', 'tomato'
 ];
-$current_dir     = getcwd(); // Get current directory
+$current_dir     = getcwd();
 $green           = '#28a745';
 $latest_version  = get_latest_release_tag($api_url);
 $message_color   = '#dc3545'; // Red by default
 $message_text    = '';
 $random_color    = $colors[array_rand($colors)];
-$sibling_folders = get_sibling_folders($current_dir); // Get sibling folder names excluding current directory
+$sibling_folders = get_sibling_folders($current_dir);
 $version_message = compare_versions(CURRENT_VERSION, $latest_version);
 
-// ****************************************************************************************
-// * Define functions for backup, deletion, and version handling
-// ****************************************************************************************
+/******************************************************************************/
+
+/**
+ * Define functions for backup, deletion, and version handling
+ */
+
 /**
  * Recursively copies files and directories from the source to the destination.
  *
  * @param string $source The source directory to back up.
- * @param string $destination The destination directory where the backup will be stored.
+ * @param string $destination The directory where the backup will be stored.
  * @return int The number of files copied.
  */
+ 
 function backup_folder($source, $destination) {
     if (!is_dir($source)) {
         return 0;
@@ -67,6 +74,7 @@ function backup_folder($source, $destination) {
  * @param string $latest_version The latest version from GitHub.
  * @return string A message indicating the version status.
  */
+
 function compare_versions($current_version, $latest_version) {
     // Switch on the compared versions with the 'v' prefix removed
     switch (version_compare(ltrim($current_version, 'v'), ltrim($latest_version, 'v'))) {
@@ -88,6 +96,7 @@ function compare_versions($current_version, $latest_version) {
  * @param string $delete_folder The path of the folder to delete.
  * @return bool True if the folder was deleted, false otherwise.
  */
+
 function delete_backup_folder($delete_folder) {
     if (!is_dir($delete_folder)) {
         return false;
@@ -107,19 +116,21 @@ function delete_backup_folder($delete_folder) {
  * @param string $dir The current directory path.
  * @return array The list of backup folders with their creation date and timestamp.
  */
+
 function get_backup_folders($dir) {
     $backup_folders = array_filter(glob($dir . '/*'), 'is_dir');
     $folder_details = [];
 
     foreach ($backup_folders as $folder) {
-        $created_date     = date('c', filectime($folder)); // ISO 8601 format for JavaScript conversion
+        // ISO 8601 date format for JavaScript conversion
+        $created_date     = date('c', filectime($folder));
         $folder_details[] = [
             'name'         => basename($folder),
             'created_date' => $created_date
         ];
     }
 
-    // Sort by created_timestamp in descending order
+    // Sort by created_date in descending order
     usort($folder_details, function($a, $b) {
         return strtotime($b['created_date']) - strtotime($a['created_date']);
     });
@@ -134,6 +145,7 @@ function get_backup_folders($dir) {
  * @return string The latest release tag name.
  */
 function get_latest_release_tag($url) {
+
     $ch = curl_init();
     curl_setopt($ch, CURLOPT_URL, $url);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
@@ -152,6 +164,7 @@ function get_latest_release_tag($url) {
  * @param string $dir The current directory path.
  * @return array The list of sibling directory names.
  */
+
 function get_sibling_folders($dir) {
     $folder_names    = [];
     $sibling_folders = array_filter(glob(dirname($dir) . '/*'), 'is_dir');
@@ -170,19 +183,26 @@ function get_sibling_folders($dir) {
     return $folder_names;
 }
 
-// ****************************************************************************************
-// * Handle POST requests for backup creation, folder deletion, and updating application
-// ****************************************************************************************
+/******************************************************************************/
+
+/**
+ * Handle POST requests for backup creation, folder deletion, and updating application
+ */
+
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     // Check if a delete action is requested
     if (isset($_POST['delete'])) {
+
         // Construct the path to the folder and attempt to delete it
         if (delete_backup_folder($current_dir . '/' . $_POST['delete'])) {
+
             // Set success message if deletion is successful
             $message_text  = "The folder '" . $_POST['delete'] . "' has been deleted.";
             $message_color = $green;
+
         } else {
+
             // Set error message if deletion fails
             $message_text = "Failed to delete the folder '" . $_POST['delete'] . "'.";
         }
@@ -205,9 +225,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         // Check if any folders are selected for backup
         if (!isset($_POST['backup_folders']) || empty($_POST['backup_folders'])) {
             $message_text = 'No folders selected for backup.';
+
+
         } else {
+
             // Loop through selected folders and initiate backup
             foreach ($_POST['backup_folders'] as $selected_folder) {
+
                 // Define the source path for backup
                 $source = '../' . $selected_folder;
 
@@ -216,18 +240,24 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
                 // Check if the destination folder already exists
                 if (is_dir($folder_name)) {
+
                     // Set error message if the destination folder already exists
                     $message_text .= "The folder '" . $folder_name . "' already exists. Backup cannot be completed.<br>";
+
                 } else {
+
                     // Perform the backup operation
                     $file_count = backup_folder($source, $folder_name);
 
                     // Check if files are successfully backed up
                     if ($file_count > 0) {
+
                         // Set success message if backup operation is successful
                         $message_text .= "The folder '" . $folder_name . "' has been created with " . ($file_count - 1) . ' files/folders.<br>';
                         $message_color = $green;
+
                     } else {
+
                         // Set error message if backup operation fails
                         $message_text .= "ERROR: '" . $folder_name . "' is not a valid directory!<br>";
                     }
@@ -462,9 +492,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <form method='POST'>
             <input type='text' id='folder_name' name='folder_name' placeholder='Backup Name' required>
             <div class='checkbox-columns'><?php
+
+                // Get folder count, set max columns, and calculate actual columns
                 $folders_count = count($sibling_folders);
-                $max_columns   = 4; // Maximum number of columns
-                $table_columns = min($max_columns, $folders_count); // Calculate number of columns
+                $max_columns   = 4;
+                $table_columns = min($max_columns, $folders_count);
 
                 // Print columns
                 for ($i = 0; $i < $table_columns; $i++) {

--- a/index.php
+++ b/index.php
@@ -159,6 +159,11 @@ function get_sibling_folders($dir) {
             $sibling_folders[] = $folder_name;
         }
     }
+
+    usort($sibling_folders, function($a, $b) {
+        return strcasecmp($a, $b);
+    });
+
     return $sibling_folders;
 }
 

--- a/index.php
+++ b/index.php
@@ -13,6 +13,7 @@ define('CURRENT_VERSION', 'v1.1.1');
  */
 
 $api_url         = 'https://api.github.com/repos/dynamiccookies/Simple-Backup-Utility/releases';
+$backup_folders  = get_backup_folders(__DIR__);
 $colors          = [
     'blue', 'blueviolet', 'brown', 'cadetblue', 'chocolate', 'crimson', 
     'darkblue', 'darkcyan', 'darkgray', 'darkgreen', 'darkmagenta', 
@@ -23,7 +24,6 @@ $colors          = [
     'palevioletred', 'peru', 'purple', 'rebeccapurple', 'red', 'seagreen', 
     'sienna', 'slategray', 'steelblue', 'teal', 'tomato'
 ];
-$current_dir     = getcwd();
 $green           = '#28a745';
 $latest_version  = get_latest_release(
     $api_url, 
@@ -34,7 +34,7 @@ $message_text    = '';
 $random_color    = $colors[array_rand($colors)];
 $red             = '#dc3545';
 $release_url     = 'https://github.com/dynamiccookies/Simple-Backup-Utility/releases/tag/$latest_version';
-$sibling_folders = get_sibling_folders($current_dir);
+$sibling_folders = get_sibling_folders(__DIR__);
 $version_message = compare_versions(
     CURRENT_VERSION, 
     $latest_version, 
@@ -317,7 +317,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     } elseif (isset($_POST['delete'])) {
 
         // Construct the path to the folder and attempt to delete it
-        if (delete_backup_folder($current_dir . '/' . $_POST['delete'])) {
+        if (delete_backup_folder(__DIR__ . '/' . $_POST['delete'])) {
 
             // Set success message if deletion is successful
             $message_color = $green;
@@ -604,9 +604,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <!-- Horizontal divider line -->
         <div class='divider'></div>
         <?php
-
-            $backup_folders = get_backup_folders($current_dir);
-
             if (empty($backup_folders)) {
                 echo '<h2>No Backups Found</h2>';
             } else {

--- a/index.php
+++ b/index.php
@@ -24,8 +24,8 @@ $colors          = [
 ];
 $current_dir     = getcwd();
 $green           = '#28a745';
-$latest_version  = get_latest_release_tag($api_url);
 $message_color   = '#dc3545'; // Red by default
+$latest_version  = get_latest_release($api_url, 'dynamiccookies/Simple-Backup-Utility');
 $message_text    = '';
 $random_color    = $colors[array_rand($colors)];
 $sibling_folders = get_sibling_folders($current_dir);
@@ -144,12 +144,12 @@ function get_backup_folders($dir) {
  * @param string $url The GitHub API URL to fetch the releases.
  * @return string The latest release tag name.
  */
-function get_latest_release_tag($url) {
 
+function get_latest_release($url, $repo) {
     $ch = curl_init();
     curl_setopt($ch, CURLOPT_URL, $url);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-    curl_setopt($ch, CURLOPT_USERAGENT, 'dynamiccookies/Simple-Backup-Utility');
+    curl_setopt($ch, CURLOPT_USERAGENT, $repo);
     $response = curl_exec($ch);
     curl_close($ch);
 

--- a/index.php
+++ b/index.php
@@ -432,6 +432,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         button:hover {
             background-color: #0056b3;
         }
+        <?php if ($message_text) { ?>
+
         .message {
             background-color: <?= $message_color; ?>;
             color: #fff;
@@ -440,6 +442,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             margin-bottom: 10px;
             transition: opacity 2s ease-out;
         }
+        <?php } ?>
+
         table {
             width: 100%;
             border-collapse: collapse;
@@ -533,19 +537,19 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 }
             }
         });
+        <?php if ($message_text) { ?>
 
         // Show message for 10 seconds
         setTimeout(function() {
             var messageDiv = document.getElementById('message');
-            if (messageDiv) {
-                messageDiv.classList.add('fade-out');
+            messageDiv.classList.add('fade-out');
 
-                // Hide message container after 2 second fade out
-                setTimeout(function() {
-                    messageDiv.style.display = 'none';
-                }, 2000);
-            }
+            // Hide message container after 2 second fade out
+            setTimeout(function() {
+                messageDiv.style.display = 'none';
+            }, 2000);
         }, 10000);
+        <?php } ?>
 
         // Function to confirm folder deletion and submit the form
         function confirmDelete(folderName, formId) {

--- a/index.php
+++ b/index.php
@@ -29,8 +29,9 @@ $message_color   = '';
 $message_text    = '';
 $random_color    = $colors[array_rand($colors)];
 $red             = '#dc3545';
+$release_url     = 'https://github.com/dynamiccookies/Simple-Backup-Utility/releases/tag/$latest_version';
 $sibling_folders = get_sibling_folders($current_dir);
-$version_message = compare_versions(CURRENT_VERSION, $latest_version);
+$version_message = compare_versions(CURRENT_VERSION, $latest_version, $release_url);
 
 /******************************************************************************/
 
@@ -76,11 +77,10 @@ function backup_folder($source, $destination) {
  * @return string A message indicating the version status.
  */
 
-function compare_versions($current_version, $latest_version) {
+function compare_versions($current_version, $latest_version, $release_url) {
     // Switch on the compared versions with the 'v' prefix removed
     switch (version_compare(ltrim($current_version, 'v'), ltrim($latest_version, 'v'))) {
         case -1:
-            $release_url = 'https://github.com/dynamiccookies/Simple-Backup-Utility/releases/tag/$latest_version';
             return "New version <a href='" . $release_url . "' target='_blank'>" . $latest_version . "</a> available! (<a href='#' onclick='triggerUpdate(); return false;'>Update Now</a>)";
 
         case 0:

--- a/index.php
+++ b/index.php
@@ -24,10 +24,11 @@ $colors          = [
 ];
 $current_dir     = getcwd();
 $green           = '#28a745';
-$message_color   = '#dc3545'; // Red by default
 $latest_version  = get_latest_release($api_url, 'dynamiccookies/Simple-Backup-Utility');
+$message_color   = '';
 $message_text    = '';
 $random_color    = $colors[array_rand($colors)];
+$red             = '#dc3545';
 $sibling_folders = get_sibling_folders($current_dir);
 $version_message = compare_versions(CURRENT_VERSION, $latest_version);
 
@@ -198,13 +199,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         if (delete_backup_folder($current_dir . '/' . $_POST['delete'])) {
 
             // Set success message if deletion is successful
-            $message_text  = "The folder '" . $_POST['delete'] . "' has been deleted.";
             $message_color = $green;
+            $message_text  = "The folder '" . $_POST['delete'] . "' has been deleted.";
 
         } else {
 
             // Set error message if deletion fails
-            $message_text = "Failed to delete the folder '" . $_POST['delete'] . "'.";
+            $message_color = $red;
+            $message_text  = "Failed to delete the folder '" . $_POST['delete'] . "'.";
         }
 
     // Check if an update action is requested
@@ -224,8 +226,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
         // Check if any folders are selected for backup
         if (!isset($_POST['backup_folders']) || empty($_POST['backup_folders'])) {
-            $message_text = 'No folders selected for backup.';
 
+            // Set error message if no folders were selected
+            $message_color = $red;
+            $message_text  = 'No folders selected for backup.';
 
         } else {
 
@@ -242,6 +246,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 if (is_dir($folder_name)) {
 
                     // Set error message if the destination folder already exists
+                    $message_color = $red;
                     $message_text .= "The folder '" . $folder_name . "' already exists. Backup cannot be completed.<br>";
 
                 } else {
@@ -253,19 +258,21 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     if ($file_count > 0) {
 
                         // Set success message if backup operation is successful
-                        $message_text .= "The folder '" . $folder_name . "' has been created with " . ($file_count - 1) . ' files/folders.<br>';
                         $message_color = $green;
+                        $message_text .= "The folder '" . $folder_name . "' has been created with " . ($file_count - 1) . ' files/folders.<br>';
 
                     } else {
 
                         // Set error message if backup operation fails
+                        $message_color = $red;
                         $message_text .= "ERROR: '" . $folder_name . "' is not a valid directory!<br>";
                     }
                 }
             }
         }
     } else {
-        $message_text = 'How did you get here?';
+        $message_color = $red;
+        $message_text  = 'How did you get here?';
     }
 }
 

--- a/index.php
+++ b/index.php
@@ -14,24 +14,32 @@ define('CURRENT_VERSION', 'v1.0.0');
 
 $api_url         = 'https://api.github.com/repos/dynamiccookies/Simple-Backup-Utility/releases';
 $colors          = [
-    'blue', 'blueviolet', 'brown', 'cadetblue', 'chocolate', 'crimson', 'darkblue', 
-    'darkcyan', 'darkgray', 'darkgreen', 'darkmagenta', 'darkolivegreen', 'darkorchid', 
-    'darkred', 'darkslateblue', 'darkslategray', 'darkviolet', 'deeppink', 'dimgray', 
-    'firebrick', 'forestgreen', 'gray', 'green', 'indianred', 'magenta', 'maroon', 
-    'mediumblue', 'mediumvioletred', 'midnightblue', 'navy', 'orangered', 'palevioletred', 
-    'peru', 'purple', 'rebeccapurple', 'red', 'seagreen', 'sienna', 'slategray', 'steelblue', 
-    'teal', 'tomato'
+    'blue', 'blueviolet', 'brown', 'cadetblue', 'chocolate', 'crimson', 
+    'darkblue', 'darkcyan', 'darkgray', 'darkgreen', 'darkmagenta', 
+    'darkolivegreen', 'darkorchid', 'darkred', 'darkslateblue', 
+    'darkslategray', 'darkviolet', 'deeppink', 'dimgray', 'firebrick', 
+    'forestgreen', 'gray', 'green', 'indianred', 'magenta', 'maroon', 
+    'mediumblue', 'mediumvioletred', 'midnightblue', 'navy', 'orangered', 
+    'palevioletred', 'peru', 'purple', 'rebeccapurple', 'red', 'seagreen', 
+    'sienna', 'slategray', 'steelblue', 'teal', 'tomato'
 ];
 $current_dir     = getcwd();
 $green           = '#28a745';
-$latest_version  = get_latest_release($api_url, 'dynamiccookies/Simple-Backup-Utility');
+$latest_version  = get_latest_release(
+    $api_url, 
+    'dynamiccookies/Simple-Backup-Utility'
+);
 $message_color   = '';
 $message_text    = '';
 $random_color    = $colors[array_rand($colors)];
 $red             = '#dc3545';
 $release_url     = 'https://github.com/dynamiccookies/Simple-Backup-Utility/releases/tag/$latest_version';
 $sibling_folders = get_sibling_folders($current_dir);
-$version_message = compare_versions(CURRENT_VERSION, $latest_version, $release_url);
+$version_message = compare_versions(
+    CURRENT_VERSION, 
+    $latest_version, 
+    $release_url
+);
 
 /******************************************************************************/
 
@@ -79,9 +87,16 @@ function backup_folder($source, $destination) {
 
 function compare_versions($current_version, $latest_version, $release_url) {
     // Switch on the compared versions with the 'v' prefix removed
-    switch (version_compare(ltrim($current_version, 'v'), ltrim($latest_version, 'v'))) {
+    switch (
+        version_compare(
+            ltrim($current_version, 'v'), 
+            ltrim($latest_version, 'v')
+        )
+    ) {
         case -1:
-            return "New version <a href='" . $release_url . "' target='_blank'>" . $latest_version . "</a> available! (<a href='#' onclick='triggerUpdate(); return false;'>Update Now</a>)";
+            return "New version <a href='" . $release_url . "' target='_blank'>"
+                . $latest_version
+                . "</a> available! (<a href='#' onclick='triggerUpdate(); return false;'>Update Now</a>)";
 
         case 0:
             return $current_version;
@@ -115,7 +130,7 @@ function delete_backup_folder($delete_folder) {
  * Retrieves the list of backup folders in the current directory.
  *
  * @param string $dir The current directory path.
- * @return array The list of backup folders with their creation date and timestamp.
+ * @return array The list of backup folders with their creation date.
  */
 
 function get_backup_folders($dir) {
@@ -184,10 +199,61 @@ function get_sibling_folders($dir) {
     return $folder_names;
 }
 
+/**
+ * Generates HTML for displaying sibling folders as columns of checkboxes.
+ *
+ * @param array $sibling_folders An array of sibling folder names.
+ * @return string The generated HTML string with checkbox columns.
+ */
+
+function print_columns($sibling_folders) {
+
+    // Get folder count, set max columns, and calc actual columns
+    $folders_count = count($sibling_folders);
+    $html          = '';
+    $max_columns   = 4;
+    $table_columns = min($max_columns, $folders_count);
+
+    // Print columns
+    for ($i = 0; $i < $table_columns; $i++) {
+        $html .= "\n\t\t\t\t<div class='checkbox-column'>";
+        for ($j = $i; $j < $folders_count; $j += $table_columns) {
+            $html .= "\n\t\t\t\t\t" . '<label for="backup_'
+                . $sibling_folders[$j] . '">';
+            $html .= '<input type="checkbox" id="backup_' . $sibling_folders[$j]
+                . '" name="backup_folders[]" value="' . $sibling_folders[$j]
+                . '">';
+            $html .= $sibling_folders[$j];
+            $html .= '</label><br>';
+        }
+        $html .= "\n\t\t\t\t</div>";
+    }
+
+    return $html;
+}
+
+/**
+ * Generates HTML to display a message if the message text is provided.
+ *
+ * @param string $message_text The text of the message to display.
+ * @return string The generated HTML string with the message or an empty string.
+ */
+
+function show_message($message_text) {
+
+    // Return HTML message if $message_text contains data
+    if ($message_text) {
+        return "<div id='message' class='message'>" . $message_text . '</div>';
+    }
+
+    return '';
+}
+
 /******************************************************************************/
 
 /**
- * Handle POST requests for backup creation, folder deletion, and updating application
+ * Handle POST requests for backup folder creation, folder deletion, and 
+ * updating the application
  */
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
@@ -200,23 +266,40 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
             // Set success message if deletion is successful
             $message_color = $green;
-            $message_text  = "The folder '" . $_POST['delete'] . "' has been deleted.";
+            $message_text  = "The folder '"
+                . $_POST['delete']
+                . "' has been deleted.";
 
         } else {
 
             // Set error message if deletion fails
             $message_color = $red;
-            $message_text  = "Failed to delete the folder '" . $_POST['delete'] . "'.";
+            $message_text  = "Failed to delete the folder '"
+                . $_POST['delete'] . "'.";
         }
 
     // Check if an update action is requested
     } elseif (isset($_POST['update'])) {
 
         // Fetch release information from GitHub API
-        $release_info = file_get_contents($api_url, false, stream_context_create(['http' => ['method' => 'GET','header' => 'User-Agent: PHP']]));
+        $release_info = file_get_contents(
+            $api_url, 
+            false, 
+            stream_context_create(
+                ['http' => ['method' => 'GET','header' => 'User-Agent: PHP']]
+            )
+        );
 
         // Download the release and save the zip file to disk
-        file_put_contents(basename(__FILE__), file_get_contents(json_decode($release_info, true)[0]['assets'][0]['browser_download_url']));
+        file_put_contents(
+            basename(__FILE__), 
+            file_get_contents(
+                json_decode(
+                    $release_info, 
+                    true
+                )[0]['assets'][0]['browser_download_url']
+            )
+        );
 
         header('Location: ' . $_SERVER['PHP_SELF']);
         exit();
@@ -225,7 +308,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     } elseif (isset($_POST['backup'])) {
 
         // Check if any folders are selected for backup
-        if (!isset($_POST['backup_folders']) || empty($_POST['backup_folders'])) {
+        if (
+            !isset($_POST['backup_folders']) || empty($_POST['backup_folders'])
+        ) {
 
             // Set error message if no folders were selected
             $message_color = $red;
@@ -240,14 +325,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $source = '../' . $selected_folder;
 
                 // Define the destination folder name and path
-                $folder_name = $selected_folder . '_' . preg_replace('/\s+/', '-', trim($_POST['folder_name']));
+                $folder_name = $selected_folder . '_'
+                    . preg_replace('/\s+/', '-', trim($_POST['folder_name']));
 
                 // Check if the destination folder already exists
                 if (is_dir($folder_name)) {
 
                     // Set error message if the destination folder already exists
                     $message_color = $red;
-                    $message_text .= "The folder '" . $folder_name . "' already exists. Backup cannot be completed.<br>";
+                    $message_text .= "The folder '" . $folder_name
+                        . "' already exists. Backup cannot be completed.<br>";
 
                 } else {
 
@@ -259,13 +346,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
                         // Set success message if backup operation is successful
                         $message_color = $green;
-                        $message_text .= "The folder '" . $folder_name . "' has been created with " . ($file_count - 1) . ' files/folders.<br>';
+                        $message_text .= "The folder '" . $folder_name
+                            . "' has been created with " . ($file_count - 1)
+                            . ' files/folders.<br>';
 
                     } else {
 
                         // Set error message if backup operation fails
                         $message_color = $red;
-                        $message_text .= "ERROR: '" . $folder_name . "' is not a valid directory!<br>";
+                        $message_text .= "ERROR: '" . $folder_name
+                            . "' is not a valid directory!<br>";
                     }
                 }
             }
@@ -502,37 +592,20 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <!-- Backup form for creating new backups -->
         <form method='POST'>
             <input type='text' id='folder_name' name='folder_name' placeholder='Backup Name' required>
-            <div class='checkbox-columns'><?php
-
-                // Get folder count, set max columns, and calculate actual columns
-                $folders_count = count($sibling_folders);
-                $max_columns   = 4;
-                $table_columns = min($max_columns, $folders_count);
-
-                // Print columns
-                for ($i = 0; $i < $table_columns; $i++) {
-                    echo "\n\t\t\t\t<div class='checkbox-column'>";
-                    for ($j = $i; $j < $folders_count; $j += $table_columns) {
-                        echo "\n\t\t\t\t\t" . '<label for="backup_' . $sibling_folders[$j] . '">';
-                        echo '<input type="checkbox" id="backup_' . $sibling_folders[$j] . '" name="backup_folders[]" value="' . $sibling_folders[$j] . '">';
-                        echo $sibling_folders[$j];
-                        echo '</label><br>';
-                    }
-                    echo "\n\t\t\t\t</div>";
-                }
-                ?>
-
+            <div class='checkbox-columns'>
+                <?= print_columns($sibling_folders); ?>
             </div>
             <button type='submit' name='backup' class='backup'>Backup Selected Folders</button>
         </form>
 
         <!-- Display message if there is any -->
-        <?php if ($message_text) echo "<div id='message' class='message'>" . $message_text . '</div>'; ?>
+        <?= show_message($message_text); ?>
 
         <!-- Horizontal divider line -->
         <div class='divider'></div>
 
         <?php
+
             $backup_folders = get_backup_folders($current_dir);
 
             if (empty($backup_folders)) {

--- a/index.php
+++ b/index.php
@@ -10,18 +10,18 @@ define('CURRENT_VERSION', 'v1.0.0');
 // ****************************************************************************************
 $api_url         = 'https://api.github.com/repos/dynamiccookies/Simple-Backup-Utility/releases';
 $colors          = [
-    "blue", "blueviolet", "brown", "cadetblue", "chocolate", "crimson", "darkblue", 
-    "darkcyan", "darkgray", "darkgreen", "darkmagenta", "darkolivegreen", "darkorchid", 
-    "darkred", "darkslateblue", "darkslategray", "darkviolet", "deeppink", "dimgray", 
-    "firebrick", "forestgreen", "gray", "green", "indianred", "magenta", "maroon", 
-    "mediumblue", "mediumvioletred", "midnightblue", "navy", "orangered", "palevioletred", 
-    "peru", "purple", "rebeccapurple", "red", "seagreen", "sienna", "slategray", "steelblue", 
-    "teal", "tomato"
+    'blue', 'blueviolet', 'brown', 'cadetblue', 'chocolate', 'crimson', 'darkblue', 
+    'darkcyan', 'darkgray', 'darkgreen', 'darkmagenta', 'darkolivegreen', 'darkorchid', 
+    'darkred', 'darkslateblue', 'darkslategray', 'darkviolet', 'deeppink', 'dimgray', 
+    'firebrick', 'forestgreen', 'gray', 'green', 'indianred', 'magenta', 'maroon', 
+    'mediumblue', 'mediumvioletred', 'midnightblue', 'navy', 'orangered', 'palevioletred', 
+    'peru', 'purple', 'rebeccapurple', 'red', 'seagreen', 'sienna', 'slategray', 'steelblue', 
+    'teal', 'tomato'
 ];
 $current_dir     = getcwd(); // Get current directory
 $green           = '#28a745';
 $latest_version  = get_latest_release_tag($api_url);
-$message_color   = "#dc3545"; // Red by default
+$message_color   = '#dc3545'; // Red by default
 $message_text    = '';
 $random_color    = $colors[array_rand($colors)];
 $sibling_folders = get_sibling_folders($current_dir); // Get sibling folder names excluding current directory
@@ -46,8 +46,8 @@ function backup_folder($source, $destination) {
     $files = array_diff(scandir($source), array('.', '..'));
 
     foreach ($files as $file) {
-        $src = "$source/$file";
-        $dst = "$destination/$file";
+        $src = $source . '/' . $file;
+        $dst = $destination . '/' . $file;
         if (is_dir($src)) {
             $count += backup_folder($src, $dst);
         } else {
@@ -70,11 +70,11 @@ function compare_versions($current_version, $latest_version) {
     switch (version_compare(ltrim($current_version, 'v'), ltrim($latest_version, 'v'))) {
         case -1:
             $release_url = 'https://github.com/dynamiccookies/Simple-Backup-Utility/releases/tag/$latest_version';
-            return "New version <a href='$release_url' target='_blank'>$latest_version</a> available! (<a href='#' onclick='triggerUpdate(); return false;'>Update Now</a>)";
+            return "New version <a href='" . $release_url . "' target='_blank'>" . $latest_version . "</a> available! (<a href='#' onclick='triggerUpdate(); return false;'>Update Now</a>)";
         case 0:
             return $current_version;
         case 1:
-            return "BETA-$current_version INSTALLED";
+            return 'BETA-' . $current_version . 'INSTALLED';
     }
 }
 
@@ -90,7 +90,7 @@ function delete_backup_folder($delete_folder) {
     }
     $files = array_diff(scandir($delete_folder), array('.', '..'));
     foreach ($files as $file) {
-        $path = "$folder/$file";
+        $path = $folder . '/' . $file;
         is_dir($path) ? delete_backup_folder($path) : unlink($path);
     }
     return rmdir($delete_folder);
@@ -173,11 +173,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         // Construct the path to the folder and attempt to delete it
         if (delete_backup_folder($current_dir . '/' . $_POST['delete'])) {
             // Set success message if deletion is successful
-            $message_text  = "The folder '{$_POST['delete']}' has been deleted.";
+            $message_text  = "The folder '" . $_POST['delete'] . "' has been deleted.";
             $message_color = $green;
         } else {
             // Set error message if deletion fails
-            $message_text = "Failed to delete the folder '{$_POST['delete']}'.";
+            $message_text = "Failed to delete the folder '" . $_POST['delete'] . "'.";
         }
 
     // Check if an update action is requested
@@ -189,7 +189,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         // Download the release and save the zip file to disk
         file_put_contents(basename(__FILE__), file_get_contents(json_decode($release_info, true)[0]['assets'][0]['browser_download_url']));
 
-        header("Location: " . $_SERVER['PHP_SELF']);
+        header('Location: ' . $_SERVER['PHP_SELF']);
         exit();
 
     // Check if a backup action is requested
@@ -202,7 +202,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             // Loop through selected folders and initiate backup
             foreach ($_POST['backup_folders'] as $selected_folder) {
                 // Define the source path for backup
-                $source = "../" . $selected_folder;
+                $source = '../' . $selected_folder;
 
                 // Define the destination folder name and path
                 $folder_name = $selected_folder . '_' . preg_replace('/\s+/', '-', trim($_POST['folder_name']));
@@ -210,7 +210,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 // Check if the destination folder already exists
                 if (is_dir($folder_name)) {
                     // Set error message if the destination folder already exists
-                    $message_text .= "The folder '$folder_name' already exists. Backup cannot be completed.<br>";
+                    $message_text .= "The folder '" . $folder_name . "' already exists. Backup cannot be completed.<br>";
                 } else {
                     // Perform the backup operation
                     $file_count = backup_folder($source, $folder_name);
@@ -218,11 +218,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     // Check if files are successfully backed up
                     if ($file_count > 0) {
                         // Set success message if backup operation is successful
-                        $message_text .= "The folder '$folder_name' has been created with " . ($file_count - 1) . " files/folders.<br>";
+                        $message_text .= "The folder '" . $folder_name . "' has been created with " . ($file_count - 1) . ' files/folders.<br>';
                         $message_color = $green;
                     } else {
                         // Set error message if backup operation fails
-                        $message_text .= "ERROR: '$folder_name' is not a valid directory!<br>";
+                        $message_text .= "ERROR: '" . $folder_name . "' is not a valid directory!<br>";
                     }
                 }
             }
@@ -235,11 +235,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 ?>
 
 <!DOCTYPE html>
-<html lang="en">
+<html lang='en'>
 <head>
-    <meta charset="UTF-8">
+    <meta charset='UTF-8'>
     <title>Backup Utility</title>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
+    <link rel='stylesheet' href='https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css'>
     <style>
         body {
             background-color: #000;
@@ -265,7 +265,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             flex-direction: column;
             align-items: center;
         }
-        input[type="text"] {
+        input[type='text'] {
             padding: 8px;
             font-size: 16px;
             border: 1px solid #ccc;
@@ -379,21 +379,21 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     </style>
     <script>
         // Set container's min-width based on the content's width
-        document.addEventListener("DOMContentLoaded", function() {
+        document.addEventListener('DOMContentLoaded', function() {
 
             // Select the container element
-            var container = document.querySelector(".container");
+            var container = document.querySelector('.container');
 
             // Set the initial width of the container
             updateContainerWidth();
 
             // Listen for window resize events to adjust the width
-            window.addEventListener("resize", updateContainerWidth);
+            window.addEventListener('resize', updateContainerWidth);
 
             // Update the container's min-width based on its scrollWidth.
             function updateContainerWidth() {
                 if (container.clientWidth + 42 < container.scrollWidth + 40) {
-                    container.style.minWidth = container.scrollWidth + "px";
+                    container.style.minWidth = container.scrollWidth + 'px';
                 }
             }
         });
@@ -411,7 +411,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
         // Function to confirm folder deletion and submit the form
         function confirmDelete(folderName, formId) {
-            if (confirm(`Are you sure you want to delete the folder "${folderName}"?`)) {
+            if (confirm('Are you sure you want to delete the folder "' + folderName + '"?')) {
                 document.getElementById(formId).submit();
             }
         }
@@ -448,13 +448,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     </script>
 </head>
 <body>
-    <div class="container">
+    <div class='container'>
         <h1>Backup Utility</h1>
 
         <!-- Backup form for creating new backups -->
-        <form method="POST">
-            <input type="text" id="folder_name" name="folder_name" placeholder="Backup Name" required>
-            <div class="checkbox-columns"><?php
+        <form method='POST'>
+            <input type='text' id='folder_name' name='folder_name' placeholder='Backup Name' required>
+            <div class='checkbox-columns'><?php
                 $folders_count = count($sibling_folders);
                 $max_columns   = 4; // Maximum number of columns
                 $table_columns = min($max_columns, $folders_count); // Calculate number of columns
@@ -473,14 +473,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 ?>
 
             </div>
-            <button type="submit" name="backup" class="backup">Backup Selected Folders</button>
+            <button type='submit' name='backup' class='backup'>Backup Selected Folders</button>
         </form>
 
         <!-- Display message if there is any -->
-        <?php if ($message_text) echo "<div id='message' class='message'>$message_text</div>"; ?>
+        <?php if ($message_text) echo "<div id='message' class='message'>" . $message_text . '</div>'; ?>
 
         <!-- Horizontal divider line -->
-        <div class="divider"></div>
+        <div class='divider'></div>
 
         <?php
             $backup_folders = get_backup_folders($current_dir);
@@ -505,12 +505,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             ?><tr>
                 <td><?php echo htmlspecialchars(explode('_', $folder['name'], 2)[0]); ?></td>
                 <td><?php echo htmlspecialchars(explode('_', $folder['name'], 2)[1]); ?></td>
-                <td class="created-date" data-iso-date="<?php echo $folder['created_date']; ?>"><?php echo $folder['created_date']; ?></td>
+                <td class='created-date' data-iso-date='<?php echo $folder['created_date']; ?>'><?php echo $folder['created_date']; ?></td>
                 <td>
-                    <form method="POST" class="inline-form" id="delete-form-<?php echo $index; ?>">
-                        <input type="hidden" name="delete" value="<?php echo htmlspecialchars($folder['name']); ?>">
-                        <button type="button" class="trash-icon" onclick="confirmDelete('<?php echo htmlspecialchars($folder['name']); ?>', 'delete-form-<?php echo $index; ?>')">
-                            <i class="fa fa-trash"></i> <!-- Trash icon for delete button -->
+                    <form method='POST' class='inline-form' id='delete-form-<?php echo $index; ?>'>
+                        <input type='hidden' name='delete' value='<?php echo htmlspecialchars($folder['name']); ?>'>
+                        <button type='button' class='trash-icon' onclick="confirmDelete('<?php echo htmlspecialchars($folder['name']); ?>', 'delete-form-<?php echo $index; ?>')">
+                            <i class='fa fa-trash'></i> <!-- Trash icon for delete button -->
                         </button>
                     </form>
                 </td>
@@ -522,6 +522,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     </div>
 
     <!-- Display version information -->
-    <div class="version-info"><?php echo $version_message; ?></div>
+    <div class='version-info'><?php echo $version_message; ?></div>
 </body>
 </html>

--- a/index.php
+++ b/index.php
@@ -8,15 +8,8 @@ define('CURRENT_VERSION', 'v1.0.0');
 // ****************************************************************************************
 // * Define variables for API URL, directories, and other data
 // ****************************************************************************************
-$apiUrl         = 'https://api.github.com/repos/dynamiccookies/Simple-Backup-Utility/releases';
-$current_dir    = getcwd(); // Get current directory
-$folders        = get_sibling_folders($current_dir); // Get sibling folder names excluding current directory
-$green          = '#28a745';
-$latestVersion  = get_latest_release_tag($apiUrl);
-$message        = '';
-$messageColor   = "#dc3545";
-$versionMessage = compare_versions(CURRENT_VERSION, $latestVersion);
-$colors         = [
+$api_url         = 'https://api.github.com/repos/dynamiccookies/Simple-Backup-Utility/releases';
+$colors          = [
     "blue", "blueviolet", "brown", "cadetblue", "chocolate", "crimson", "darkblue", 
     "darkcyan", "darkgray", "darkgreen", "darkmagenta", "darkolivegreen", "darkorchid", 
     "darkred", "darkslateblue", "darkslategray", "darkviolet", "deeppink", "dimgray", 
@@ -25,7 +18,14 @@ $colors         = [
     "peru", "purple", "rebeccapurple", "red", "seagreen", "sienna", "slategray", "steelblue", 
     "teal", "tomato"
 ];
-$random_color = $colors[array_rand($colors)];
+$current_dir     = getcwd(); // Get current directory
+$green           = '#28a745';
+$latest_version  = get_latest_release_tag($api_url);
+$message_color   = "#dc3545"; // Red by default
+$message_text    = '';
+$random_color    = $colors[array_rand($colors)];
+$sibling_folders = get_sibling_folders($current_dir); // Get sibling folder names excluding current directory
+$version_message = compare_versions(CURRENT_VERSION, $latest_version);
 
 // ****************************************************************************************
 // * Define functions for backup, deletion, and version handling
@@ -61,43 +61,39 @@ function backup_folder($source, $destination) {
 /**
  * Compares the current version with the latest version from GitHub.
  *
- * @param string $currentVersion The current version of the utility.
- * @param string $latestVersion The latest version from GitHub.
+ * @param string $current_version The current version of the utility.
+ * @param string $latest_version The latest version from GitHub.
  * @return string A message indicating the version status.
  */
-function compare_versions($currentVersion, $latestVersion) {
-    // Remove 'v' prefix for comparison
-    $currentVersionClean = ltrim($currentVersion, 'v');
-    $latestVersionClean  = ltrim($latestVersion, 'v');
-
-    // Compare versions and switch on the result
-    switch (version_compare($currentVersionClean, $latestVersionClean)) {
+function compare_versions($current_version, $latest_version) {
+    // Switch on the compared versions with the 'v' prefix removed
+    switch (version_compare(ltrim($current_version, 'v'), ltrim($latest_version, 'v'))) {
         case -1:
-            $releaseUrl = 'https://github.com/dynamiccookies/Simple-Backup-Utility/releases/tag/$latestVersion';
-            return "New version <a href='$releaseUrl' target='_blank'>$latestVersion</a> available! (<a href='#' onclick='triggerUpdate(); return false;'>Update Now</a>)";
+            $release_url = 'https://github.com/dynamiccookies/Simple-Backup-Utility/releases/tag/$latest_version';
+            return "New version <a href='$release_url' target='_blank'>$latest_version</a> available! (<a href='#' onclick='triggerUpdate(); return false;'>Update Now</a>)";
         case 0:
-            return $currentVersion;
+            return $current_version;
         case 1:
-            return "BETA-$currentVersion INSTALLED";
+            return "BETA-$current_version INSTALLED";
     }
 }
 
 /**
  * Recursively deletes a folder and its contents.
  *
- * @param string $folder The path of the folder to delete.
+ * @param string $delete_folder The path of the folder to delete.
  * @return bool True if the folder was deleted, false otherwise.
  */
-function delete_backup_folder($folder) {
-    if (!is_dir($folder)) {
+function delete_backup_folder($delete_folder) {
+    if (!is_dir($delete_folder)) {
         return false;
     }
-    $files = array_diff(scandir($folder), array('.', '..'));
+    $files = array_diff(scandir($delete_folder), array('.', '..'));
     foreach ($files as $file) {
         $path = "$folder/$file";
         is_dir($path) ? delete_backup_folder($path) : unlink($path);
     }
-    return rmdir($folder);
+    return rmdir($delete_folder);
 }
 
 /**
@@ -107,22 +103,22 @@ function delete_backup_folder($folder) {
  * @return array The list of backup folders with their creation date and timestamp.
  */
 function get_backup_folders($dir) {
-    $folders = array_filter(glob($dir . '/*'), 'is_dir');
-    $backup_folders = [];
+    $backup_folders = array_filter(glob($dir . '/*'), 'is_dir');
+    $folder_details = [];
 
-    foreach ($folders as $folder) {
+    foreach ($backup_folders as $folder) {
         $created_date     = date('c', filectime($folder)); // ISO 8601 format for JavaScript conversion
-        $backup_folders[] = [
+        $folder_details[] = [
             'name'         => basename($folder),
             'created_date' => $created_date
         ];
     }
 
     // Sort by created_timestamp in descending order
-    usort($backup_folders, function($a, $b) {
+    usort($folder_details, function($a, $b) {
         return strtotime($b['created_date']) - strtotime($a['created_date']);
     });
-    return $backup_folders;
+    return $folder_details;
 }
 
 /**
@@ -150,21 +146,21 @@ function get_latest_release_tag($url) {
  * @return array The list of sibling directory names.
  */
 function get_sibling_folders($dir) {
-    $parent_dir = dirname($dir);
-    $folders = array_filter(glob($parent_dir . '/*'), 'is_dir');
-    $sibling_folders = [];
-    foreach ($folders as $folder) {
-        $folder_name = basename($folder);
-        if ($folder_name !== basename($dir)) {
-            $sibling_folders[] = $folder_name;
+    $folder_names    = [];
+    $sibling_folders = array_filter(glob(dirname($dir) . '/*'), 'is_dir');
+
+    foreach ($sibling_folders as $folder) {
+        $folder = basename($folder);
+        if ($folder !== basename($dir)) {
+            $folder_names[] = $folder;
         }
     }
 
-    usort($sibling_folders, function($a, $b) {
+    usort($folder_names, function($a, $b) {
         return strcasecmp($a, $b);
     });
 
-    return $sibling_folders;
+    return $folder_names;
 }
 
 // ****************************************************************************************
@@ -174,27 +170,24 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     // Check if a delete action is requested
     if (isset($_POST['delete'])) {
-        // Construct the path to the folder to delete
-        $folder_to_delete = $current_dir . '/' . $_POST['delete'];
-
-        // Attempt to delete the folder
-        if (delete_backup_folder($folder_to_delete)) {
+        // Construct the path to the folder and attempt to delete it
+        if (delete_backup_folder($current_dir . '/' . $_POST['delete'])) {
             // Set success message if deletion is successful
-            $message = "The folder '{$_POST['delete']}' has been deleted.";
-            $messageColor = $green;
+            $message_text  = "The folder '{$_POST['delete']}' has been deleted.";
+            $message_color = $green;
         } else {
             // Set error message if deletion fails
-            $message = "Failed to delete the folder '{$_POST['delete']}'.";
+            $message_text = "Failed to delete the folder '{$_POST['delete']}'.";
         }
 
     // Check if an update action is requested
     } elseif (isset($_POST['update'])) {
 
         // Fetch release information from GitHub API
-        $releaseInfo = file_get_contents($apiUrl, false, stream_context_create(['http' => ['method' => 'GET','header' => 'User-Agent: PHP']]));
+        $release_info = file_get_contents($api_url, false, stream_context_create(['http' => ['method' => 'GET','header' => 'User-Agent: PHP']]));
 
         // Download the release and save the zip file to disk
-        file_put_contents(basename(__FILE__), file_get_contents(json_decode($releaseInfo, true)[0]['assets'][0]['browser_download_url']));
+        file_put_contents(basename(__FILE__), file_get_contents(json_decode($release_info, true)[0]['assets'][0]['browser_download_url']));
 
         header("Location: " . $_SERVER['PHP_SELF']);
         exit();
@@ -204,7 +197,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
         // Check if any folders are selected for backup
         if (!isset($_POST['backup_folders']) || empty($_POST['backup_folders'])) {
-            $message = 'No folders selected for backup.';
+            $message_text = 'No folders selected for backup.';
         } else {
             // Loop through selected folders and initiate backup
             foreach ($_POST['backup_folders'] as $selected_folder) {
@@ -217,7 +210,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 // Check if the destination folder already exists
                 if (is_dir($folder_name)) {
                     // Set error message if the destination folder already exists
-                    $message .= "The folder '$folder_name' already exists. Backup cannot be completed.<br>";
+                    $message_text .= "The folder '$folder_name' already exists. Backup cannot be completed.<br>";
                 } else {
                     // Perform the backup operation
                     $file_count = backup_folder($source, $folder_name);
@@ -225,17 +218,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     // Check if files are successfully backed up
                     if ($file_count > 0) {
                         // Set success message if backup operation is successful
-                        $message     .= "The folder '$folder_name' has been created with " . ($file_count - 1) . " files/folders.<br>";
-                        $messageColor = $green;
+                        $message_text .= "The folder '$folder_name' has been created with " . ($file_count - 1) . " files/folders.<br>";
+                        $message_color = $green;
                     } else {
                         // Set error message if backup operation fails
-                        $message .= "ERROR: '$folder_name' is not a valid directory!<br>";
+                        $message_text .= "ERROR: '$folder_name' is not a valid directory!<br>";
                     }
                 }
             }
         }
     } else {
-        $message = 'How did you get here?';
+        $message_text = 'How did you get here?';
     }
 }
 
@@ -306,7 +299,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             background-color: #0056b3;
         }
         .message {
-            background-color: <?php echo "$messageColor"; ?>;
+            background-color: <?php echo $message_color; ?>;
             color: #fff;
             padding: 10px;
             border-radius: 5px;
@@ -425,13 +418,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
         // Function to trigger update from GitHub repository's latest release
         function triggerUpdate() {
-            const form = document.createElement('form');
+            const form  = document.createElement('form');
             form.method = 'post';
             form.action = '.';
 
             const updateInput = document.createElement('input');
-            updateInput.type = 'hidden';
-            updateInput.name = 'update';
+            updateInput.type  = 'hidden';
+            updateInput.name  = 'update';
             updateInput.value = 'true';
 
             form.appendChild(updateInput);
@@ -462,18 +455,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <form method="POST">
             <input type="text" id="folder_name" name="folder_name" placeholder="Backup Name" required>
             <div class="checkbox-columns"><?php
-                $total_folders = count($folders);
-                $max_columns = 4; // Maximum number of columns
-                $columns = min($max_columns, $total_folders); // Adjust columns dynamically based on folder count
-            
+                $folders_count = count($sibling_folders);
+                $max_columns   = 4; // Maximum number of columns
+                $table_columns = min($max_columns, $folders_count); // Calculate number of columns
+
                 // Print columns
-                for ($i = 0; $i < $columns; $i++) {
+                for ($i = 0; $i < $table_columns; $i++) {
                     echo "\n\t\t\t\t<div class='checkbox-column'>";
-                    for ($j = $i; $j < $total_folders; $j += $columns) {
-                        $folder = $folders[$j];
-                        echo "\n\t\t\t\t\t" . '<label for="backup_' . $folder . '">';
-                        echo '<input type="checkbox" id="backup_' . $folder . '" name="backup_folders[]" value="' . $folder . '">';
-                        echo $folder;
+                    for ($j = $i; $j < $folders_count; $j += $table_columns) {
+                        echo "\n\t\t\t\t\t" . '<label for="backup_' . $sibling_folders[$j] . '">';
+                        echo '<input type="checkbox" id="backup_' . $sibling_folders[$j] . '" name="backup_folders[]" value="' . $sibling_folders[$j] . '">';
+                        echo $sibling_folders[$j];
                         echo '</label><br>';
                     }
                     echo "\n\t\t\t\t</div>";
@@ -485,7 +477,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         </form>
 
         <!-- Display message if there is any -->
-        <?php if ($message) echo "<div id='message' class='message'>$message</div>"; ?>
+        <?php if ($message_text) echo "<div id='message' class='message'>$message_text</div>"; ?>
 
         <!-- Horizontal divider line -->
         <div class="divider"></div>
@@ -530,6 +522,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     </div>
 
     <!-- Display version information -->
-    <div class="version-info"><?php echo $versionMessage; ?></div>
+    <div class="version-info"><?php echo $version_message; ?></div>
 </body>
 </html>

--- a/index.php
+++ b/index.php
@@ -469,7 +469,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 // Print columns
                 for ($i = 0; $i < $columns; $i++) {
                     echo "\n\t\t\t\t<div class='checkbox-column'>";
-                    for ($j = 0; $j < $folders_per_column; $j++) {
                     for ($j = $i; $j < $total_folders; $j += $columns) {
                         $folder = $folders[$j];
                         echo "\n\t\t\t\t\t" . '<label for="backup_' . $folder . '">';

--- a/index.php
+++ b/index.php
@@ -4,7 +4,7 @@
  * Define constant for the current version
  */
 
-define('CURRENT_VERSION', 'v1.1.0');
+define('CURRENT_VERSION', 'v1.1.1');
 
 /******************************************************************************/
 

--- a/index.php
+++ b/index.php
@@ -224,7 +224,7 @@ function print_columns($sibling_folders) {
             $html .= $sibling_folders[$j];
             $html .= '</label><br>';
         }
-        $html .= "\n\t\t\t\t</div>";
+        $html .= "\n\t\t\t\t</div>\n";
     }
 
     return $html;
@@ -364,6 +364,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 }
 
+/******************************************************************************/
 ?>
 
 <!DOCTYPE html>
@@ -627,6 +628,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 <td><?= htmlspecialchars(explode('_', $folder['name'], 2)[0]); ?></td>
                 <td><?= htmlspecialchars(explode('_', $folder['name'], 2)[1]); ?></td>
                 <td class='created-date' data-iso-date='<?= $folder['created_date']; ?>'><?= $folder['created_date']; ?></td>
+
                 <td>
                     <form method='POST' class='inline-form' id='delete-form-<?= $index; ?>'>
                         <input type='hidden' name='delete' value='<?= htmlspecialchars($folder['name']); ?>'>
@@ -640,6 +642,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
         </table>
         <?php } ?>
+
     </div>
 
     <!-- Display version information -->

--- a/index.php
+++ b/index.php
@@ -73,8 +73,10 @@ function compare_versions($current_version, $latest_version) {
         case -1:
             $release_url = 'https://github.com/dynamiccookies/Simple-Backup-Utility/releases/tag/$latest_version';
             return "New version <a href='" . $release_url . "' target='_blank'>" . $latest_version . "</a> available! (<a href='#' onclick='triggerUpdate(); return false;'>Update Now</a>)";
+
         case 0:
             return $current_version;
+
         case 1:
             return 'BETA-' . $current_version . 'INSTALLED';
     }

--- a/index.php
+++ b/index.php
@@ -256,54 +256,8 @@ function show_message($message_text) {
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
-    // Check if a delete action is requested
-    if (isset($_POST['delete'])) {
-
-        // Construct the path to the folder and attempt to delete it
-        if (delete_backup_folder($current_dir . '/' . $_POST['delete'])) {
-
-            // Set success message if deletion is successful
-            $message_color = $green;
-            $message_text  = "The folder '"
-                . $_POST['delete']
-                . "' has been deleted.";
-
-        } else {
-
-            // Set error message if deletion fails
-            $message_color = $red;
-            $message_text  = "Failed to delete the folder '"
-                . $_POST['delete'] . "'.";
-        }
-
-    // Check if an update action is requested
-    } elseif (isset($_POST['update'])) {
-
-        // Fetch release information from GitHub API
-        $release_info = file_get_contents(
-            $api_url, 
-            false, 
-            stream_context_create(
-                ['http' => ['method' => 'GET','header' => 'User-Agent: PHP']]
-            )
-        );
-
-        // Download the release and save the zip file to disk
-        file_put_contents(
-            basename(__FILE__), 
-            file_get_contents(
-                json_decode(
-                    $release_info, 
-                    true
-                )[0]['assets'][0]['browser_download_url']
-            )
-        );
-
-        header('Location: ' . $_SERVER['PHP_SELF']);
-        exit();
-
     // Check if a backup action is requested
-    } elseif (isset($_POST['backup'])) {
+    if (isset($_POST['backup'])) {
 
         // Check if any folders are selected for backup
         if (
@@ -358,6 +312,53 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 }
             }
         }
+
+    // Check if a delete action is requested
+    } elseif (isset($_POST['delete'])) {
+
+        // Construct the path to the folder and attempt to delete it
+        if (delete_backup_folder($current_dir . '/' . $_POST['delete'])) {
+
+            // Set success message if deletion is successful
+            $message_color = $green;
+            $message_text  = "The folder '"
+                . $_POST['delete']
+                . "' has been deleted.";
+
+        } else {
+
+            // Set error message if deletion fails
+            $message_color = $red;
+            $message_text  = "Failed to delete the folder '"
+                . $_POST['delete'] . "'.";
+        }
+
+    // Check if an update action is requested
+    } elseif (isset($_POST['update'])) {
+
+        // Fetch release information from GitHub API
+        $release_info = file_get_contents(
+            $api_url, 
+            false, 
+            stream_context_create(
+                ['http' => ['method' => 'GET','header' => 'User-Agent: PHP']]
+            )
+        );
+
+        // Download the release and save the zip file to disk
+        file_put_contents(
+            basename(__FILE__), 
+            file_get_contents(
+                json_decode(
+                    $release_info, 
+                    true
+                )[0]['assets'][0]['browser_download_url']
+            )
+        );
+
+        header('Location: ' . $_SERVER['PHP_SELF']);
+        exit();
+
     } else {
         $message_color = $red;
         $message_text  = 'How did you get here?';

--- a/index.php
+++ b/index.php
@@ -436,6 +436,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
             // Update the container's min-width based on its scrollWidth.
             function updateContainerWidth() {
+
+                // Test the container's width + left & right margins
                 if (container.clientWidth + 42 < container.scrollWidth + 40) {
                     container.style.minWidth = container.scrollWidth + 'px';
                 }
@@ -447,6 +449,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             var messageDiv = document.getElementById('message');
             if (messageDiv) {
                 messageDiv.classList.add('fade-out');
+
+                // Hide message container after 2 seconds
                 setTimeout(function() {
                     messageDiv.style.display = 'none';
                 }, 2000);

--- a/index.php
+++ b/index.php
@@ -623,22 +623,25 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 <th>Delete</th>
             </tr>
             <?php
-                foreach ($backup_folders as $index => $folder):
-            ?><tr>
-                <td><?= htmlspecialchars(explode('_', $folder['name'], 2)[0]); ?></td>
-                <td><?= htmlspecialchars(explode('_', $folder['name'], 2)[1]); ?></td>
-                <td class='created-date' data-iso-date='<?= $folder['created_date']; ?>'><?= $folder['created_date']; ?></td>
+                foreach ($backup_folders as $index => $folder) {
+                    $folder_name  = htmlspecialchars($folder['name']);
+                    $created_date = htmlspecialchars($folder['created_date']);
+            ?>
 
+            <tr>
+                <td><?= explode('_', $folder_name, 2)[0]; ?></td>
+                <td><?= explode('_', $folder_name, 2)[1]; ?></td>
+                <td class='created-date' data-iso-date='<?= $folder['created_date']; ?>'><?= $created_date; ?></td>
                 <td>
                     <form method='POST' class='inline-form' id='delete-form-<?= $index; ?>'>
-                        <input type='hidden' name='delete' value='<?= htmlspecialchars($folder['name']); ?>'>
-                        <button type='button' class='trash-icon' onclick="confirmDelete('<?= htmlspecialchars($folder['name']); ?>', 'delete-form-<?= $index; ?>')">
+                        <input type='hidden' name='delete' value='<?= $folder_name; ?>'>
+                        <button type='button' class='trash-icon' onclick="confirmDelete('<?= $folder_name; ?>', 'delete-form-<?= $index; ?>')">
                             <i class='fa fa-trash'></i> <!-- Trash icon for delete button -->
                         </button>
                     </form>
                 </td>
             </tr>
-            <?php endforeach; ?>
+            <?php } ?>
 
         </table>
         <?php } ?>

--- a/index.php
+++ b/index.php
@@ -1,4 +1,5 @@
 <?php
+
 // ****************************************************************************************
 // * Set timezone to CST
 // * Define constant for the current version
@@ -253,7 +254,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             padding: 20px;
             border: 2px solid #fff;
             border-radius: 10px;
-            background-color: <?php echo $random_color; ?>;
+            background-color: <?= $random_color; ?>;
             display: inline-block;
         }
         h1, h2 {
@@ -299,7 +300,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             background-color: #0056b3;
         }
         .message {
-            background-color: <?php echo $message_color; ?>;
+            background-color: <?= $message_color; ?>;
             color: #fff;
             padding: 10px;
             border-radius: 5px;
@@ -503,13 +504,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             <?php
                 foreach ($backup_folders as $index => $folder):
             ?><tr>
-                <td><?php echo htmlspecialchars(explode('_', $folder['name'], 2)[0]); ?></td>
-                <td><?php echo htmlspecialchars(explode('_', $folder['name'], 2)[1]); ?></td>
-                <td class='created-date' data-iso-date='<?php echo $folder['created_date']; ?>'><?php echo $folder['created_date']; ?></td>
+                <td><?= htmlspecialchars(explode('_', $folder['name'], 2)[0]); ?></td>
+                <td><?= htmlspecialchars(explode('_', $folder['name'], 2)[1]); ?></td>
+                <td class='created-date' data-iso-date='<?= $folder['created_date']; ?>'><?= $folder['created_date']; ?></td>
                 <td>
-                    <form method='POST' class='inline-form' id='delete-form-<?php echo $index; ?>'>
-                        <input type='hidden' name='delete' value='<?php echo htmlspecialchars($folder['name']); ?>'>
-                        <button type='button' class='trash-icon' onclick="confirmDelete('<?php echo htmlspecialchars($folder['name']); ?>', 'delete-form-<?php echo $index; ?>')">
+                    <form method='POST' class='inline-form' id='delete-form-<?= $index; ?>'>
+                        <input type='hidden' name='delete' value='<?= htmlspecialchars($folder['name']); ?>'>
+                        <button type='button' class='trash-icon' onclick="confirmDelete('<?= htmlspecialchars($folder['name']); ?>', 'delete-form-<?= $index; ?>')">
                             <i class='fa fa-trash'></i> <!-- Trash icon for delete button -->
                         </button>
                     </form>
@@ -522,6 +523,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     </div>
 
     <!-- Display version information -->
-    <div class='version-info'><?php echo $version_message; ?></div>
+    <div class='version-info'><?= $version_message; ?></div>
 </body>
 </html>

--- a/index.php
+++ b/index.php
@@ -579,7 +579,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         // Convert all dates in the table to local timezone
         window.addEventListener('DOMContentLoaded', (event) => {
             document.querySelectorAll('.created-date').forEach(element => {
-                const isoDate = element.getAttribute('data-iso-date');
+                const isoDate       = element.getAttribute('data-iso-date');
                 element.textContent = convertToLocalTime(isoDate);
             });
         });
@@ -603,7 +603,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
         <!-- Horizontal divider line -->
         <div class='divider'></div>
-
         <?php
 
             $backup_folders = get_backup_folders($current_dir);

--- a/index.php
+++ b/index.php
@@ -4,7 +4,7 @@
  * Define constant for the current version
  */
 
-define('CURRENT_VERSION', 'v1.0.0');
+define('CURRENT_VERSION', 'v1.1.0');
 
 /******************************************************************************/
 

--- a/index.php
+++ b/index.php
@@ -56,6 +56,7 @@ function backup_folder($source, $destination) {
             $count ++;
         }
     }
+
     return $count;
 }
 
@@ -94,6 +95,7 @@ function delete_backup_folder($delete_folder) {
         $path = $folder . '/' . $file;
         is_dir($path) ? delete_backup_folder($path) : unlink($path);
     }
+
     return rmdir($delete_folder);
 }
 
@@ -119,6 +121,7 @@ function get_backup_folders($dir) {
     usort($folder_details, function($a, $b) {
         return strtotime($b['created_date']) - strtotime($a['created_date']);
     });
+
     return $folder_details;
 }
 
@@ -137,6 +140,7 @@ function get_latest_release_tag($url) {
     curl_close($ch);
 
     $releases = json_decode($response, true);
+
     return isset($releases[0]['tag_name']) ? $releases[0]['tag_name'] : '';
 }
 

--- a/index.php
+++ b/index.php
@@ -432,7 +432,36 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         button:hover {
             background-color: #0056b3;
         }
-        <?php if ($message_text) { ?>
+        .checkbox-columns {
+            display: flex;
+            gap: 20px;
+            text-align: left;
+            margin: 25px 25px 15px 25px;
+        }
+        .checkbox-column label {
+            display: block;
+            white-space: nowrap;
+            margin-bottom: 5px;
+        }
+        .divider {
+            border-top: 1px solid #fff;
+            margin: 20px 0;
+        }
+        .version-info {
+            position: fixed;
+            bottom: 0;
+            right: 0;
+            margin: 10px;
+            font-size: small;
+        }
+        .version-info a {
+            color: yellow;
+            font-weight: bold;
+        }
+        <?php
+            //Conditionally add message CSS
+            if ($message_text) {
+        ?>
 
         .message {
             background-color: <?= $message_color; ?>;
@@ -444,7 +473,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             box-shadow: 0 8px 8px 1px rgba(0, 0, 0, .2);
             font-weight: bold;
         }
-        <?php } ?>
+        .fade-out {
+            opacity: 0;
+        }
+        <?php 
+            }
+
+            // Conditionally add Existing Backups CSS
+            if (!empty($backup_folders)) { 
+        ?>
 
         table {
             width: 100%;
@@ -474,24 +511,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         table th:nth-child(4), table td:nth-child(4) {
             width: 10%;
         }
-        .checkbox-columns {
-            display: flex;
-            gap: 20px;
-            text-align: left;
-            margin: 25px 25px 15px 25px;
-        }
-        .checkbox-column label {
-            display: block;
-            white-space: nowrap;
-            margin-bottom: 5px;
-        }
-        .divider {
-            border-top: 1px solid #fff;
-            margin: 20px 0;
-        }
-        .fade-out {
-            opacity: 0;
-        }
         .inline-form {
             display: inline;
         }
@@ -505,17 +524,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         .trash-icon:hover {
             color: #c82333;
         }
-        .version-info {
-            position: fixed;
-            bottom: 0;
-            right: 0;
-            margin: 10px;
-            font-size: small;
-        }
-        .version-info a {
-            color: yellow;
-            font-weight: bold;
-        }
+        <?php } ?>
+
     </style>
     <script>
         // Set container's min-width based on the content's width

--- a/index.php
+++ b/index.php
@@ -4,7 +4,7 @@
  * Define constant for the current version
  */
 
-define('CURRENT_VERSION', 'v1.1.1');
+define('CURRENT_VERSION', 'v1.1.2');
 
 /******************************************************************************/
 

--- a/index.php
+++ b/index.php
@@ -118,7 +118,7 @@ function delete_backup_folder($delete_folder) {
     }
     $files = array_diff(scandir($delete_folder), array('.', '..'));
     foreach ($files as $file) {
-        $path = $folder . '/' . $file;
+        $path = $delete_folder . '/' . $file;
         is_dir($path) ? delete_backup_folder($path) : unlink($path);
     }
 

--- a/index.php
+++ b/index.php
@@ -138,11 +138,9 @@ function get_backup_folders($dir) {
     $folder_details = [];
 
     foreach ($backup_folders as $folder) {
-        // ISO 8601 date format for JavaScript conversion
-        $created_date     = date('c', filectime($folder));
         $folder_details[] = [
             'name'         => basename($folder),
-            'created_date' => $created_date
+            'created_date' => date('c', filectime($folder))
         ];
     }
 

--- a/index.php
+++ b/index.php
@@ -415,7 +415,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             gap: 10px;
             margin-bottom: 20px;
         }
-        button.backup, .message {
+        button.backup {
             box-shadow: 0 8px 8px 1px rgba(0, 0, 0, .2);
             font-weight: bold;
         }
@@ -441,6 +441,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             border-radius: 5px;
             margin-bottom: 10px;
             transition: opacity 2s ease-out;
+            box-shadow: 0 8px 8px 1px rgba(0, 0, 0, .2);
+            font-weight: bold;
         }
         <?php } ?>
 

--- a/index.php
+++ b/index.php
@@ -459,21 +459,18 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             <div class="checkbox-columns"><?php
                 $total_folders = count($folders);
                 $max_columns = 4; // Maximum number of columns
-                $columns = min($max_columns, max(1, ceil($total_folders / 2))); // Adjust columns dynamically based on folder count
-
-                // Calculate number of folders per column
-                $folders_per_column = ceil($total_folders / $columns);
+                $columns = min($max_columns, $total_folders); // Adjust columns dynamically based on folder count
+            
+                // Print columns
                 for ($i = 0; $i < $columns; $i++) {
                     echo "\n\t\t\t\t<div class='checkbox-column'>";
                     for ($j = 0; $j < $folders_per_column; $j++) {
-                        $folder_index = $j * $columns + $i;
-                        if ($folder_index < $total_folders) {
-                            $folder = $folders[$folder_index];
-                            echo "\n\t\t\t\t\t" . '<label for="backup_' . $folder . '">';
-                            echo '<input type="checkbox" id="backup_' . $folder . '" name="backup_folders[]" value="' . $folder . '">';
-                            echo ucfirst($folder);
-                            echo '</label><br>';
-                        }
+                    for ($j = $i; $j < $total_folders; $j += $columns) {
+                        $folder = $folders[$j];
+                        echo "\n\t\t\t\t\t" . '<label for="backup_' . $folder . '">';
+                        echo '<input type="checkbox" id="backup_' . $folder . '" name="backup_folders[]" value="' . $folder . '">';
+                        echo $folder;
+                        echo '</label><br>';
                     }
                     echo "\n\t\t\t\t</div>";
                 }

--- a/index.php
+++ b/index.php
@@ -102,7 +102,7 @@ function compare_versions($current_version, $latest_version, $release_url) {
             return $current_version;
 
         case 1:
-            return 'BETA-' . $current_version . 'INSTALLED';
+            return 'BETA-' . $current_version . ' INSTALLED';
     }
 }
 
@@ -241,7 +241,7 @@ function show_message($message_text) {
 
     // Return HTML message if $message_text contains data
     if ($message_text) {
-        return "<div id='message' class='message'>" . $message_text . '</div>';
+        return "<div id='message' class='message'>" . $message_text . "</div>\n";
     }
 
     return '';

--- a/index.php
+++ b/index.php
@@ -13,7 +13,6 @@ define('CURRENT_VERSION', 'v1.1.1');
  */
 
 $api_url         = 'https://api.github.com/repos/dynamiccookies/Simple-Backup-Utility/releases';
-$backup_folders  = get_backup_folders(__DIR__);
 $colors          = [
     'blue', 'blueviolet', 'brown', 'cadetblue', 'chocolate', 'crimson', 
     'darkblue', 'darkcyan', 'darkgray', 'darkgreen', 'darkmagenta', 
@@ -365,6 +364,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 }
 
+// Set $backup_folders after folder backup or delete
+$backup_folders = get_backup_folders(__DIR__);
 /******************************************************************************/
 ?>
 

--- a/index.php
+++ b/index.php
@@ -537,26 +537,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 }
             }
         });
-        <?php if ($message_text) { ?>
-
-        // Show message for 10 seconds
-        setTimeout(function() {
-            var messageDiv = document.getElementById('message');
-            messageDiv.classList.add('fade-out');
-
-            // Hide message container after 2 second fade out
-            setTimeout(function() {
-                messageDiv.style.display = 'none';
-            }, 2000);
-        }, 10000);
-        <?php } ?>
-
-        // Function to confirm folder deletion and submit the form
-        function confirmDelete(folderName, formId) {
-            if (confirm('Are you sure you want to delete the folder "' + folderName + '"?')) {
-                document.getElementById(formId).submit();
-            }
-        }
 
         // Function to trigger update from GitHub repository's latest release
         function triggerUpdate() {
@@ -573,6 +553,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             document.body.appendChild(form);
             form.submit();
         }
+        <?php
+            // Conditionally add Existing Backups JavaScript
+            if (!empty($backup_folders)) { 
+        ?>
+
+        // Function to confirm folder deletion and submit the form
+        function confirmDelete(folderName, formId) {
+            if (confirm('Are you sure you want to delete the folder "' + folderName + '"?')) {
+                document.getElementById(formId).submit();
+            }
+        }
 
         // Function to convert ISO 8601 date to local timezone and format
         function convertToLocalTime(isoDate) {
@@ -587,6 +578,25 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 element.textContent = convertToLocalTime(isoDate);
             });
         });
+        <?php
+            }
+
+            // Conditionally add message div JavaScript
+            if ($message_text) {
+        ?>
+
+        // Show message for 10 seconds
+        setTimeout(function() {
+            var messageDiv = document.getElementById('message');
+            messageDiv.classList.add('fade-out');
+
+            // Hide message container after 2 second fade out
+            setTimeout(function() {
+                messageDiv.style.display = 'none';
+            }, 2000);
+        }, 10000);
+        <?php } ?>
+
     </script>
 </head>
 <body>


### PR DESCRIPTION
### New Features ✨

- dc6fad9 Arrange checkboxes horizontally ([#39](https://github.com/dynamiccookies/Simple-Backup-Utility/issues/39))
  - Calculate `$column` as the smaller of `$max_columns` or `$total_folders`.
  - Updated loop to fill each column by jumping to each array item for that column.
  - Removed the `folders_per_column` variable.
  - Removed `ucfirst()` from `$folder` to show actual folder name ([#40](https://github.com/dynamiccookies/Simple-Backup-Utility/issues/40)).

- c6fc2dc Sort checkboxes by case-insensitive folder names ([#40](https://github.com/dynamiccookies/Simple-Backup-Utility/issues/40))
  - Sort checkboxes by folder names ignoring case and keeping array indexes in order.

- 9fa2b74 Increment version to v1.1.2

### Fixes 🛠️

- 5766e41 Update PHP variables ([#20](https://github.com/dynamiccookies/Simple-Backup-Utility/issues/20))
  - Standardized snake_case variable names.
  - Update variable names to be more descriptive.
  - Update variables to be in alphabetical order.
  - Remove unnecessary variables (`$currentVersionClean`, `$latestVersionClean`, `$folder_to_delete`, `$parent_dir`, `$created_date`).
  - Fix spacing and alignment.

- 4112b40 Replace double quotes with single quotes ([#20](https://github.com/dynamiccookies/Simple-Backup-Utility/issues/20))
  - Wherever possible, replace double quotes with single quotes.
  - Break out variables from string text.

- cf294cd Use PHP short echo tag ([#20](https://github.com/dynamiccookies/Simple-Backup-Utility/issues/20))
  - Replace solo PHP echo statements in HTML with PHP short echo tag.
  - Added blank line after PHP open tag.

- 16d4a95 Add blank line before function returns ([#20](https://github.com/dynamiccookies/Simple-Backup-Utility/issues/20))
  - Follow PHP Style Guide -> 9. Functions -> Function Return standards.

- 7332d40 Added blank lines to case statement ([#20](https://github.com/dynamiccookies/Simple-Backup-Utility/issues/20))
  - Following PHP Style Guide -> 10. Control Structures -> Switch, Case.

- 04d8512 Update comments ([#20](https://github.com/dynamiccookies/Simple-Backup-Utility/issues/20))
  - Update comment formatting to follow PHP Style Guide.
  - Add spacing for better readability.
  - Updated wording in some comments.

- f494a16 Add comments for ambiguous numbers ([#20](https://github.com/dynamiccookies/Simple-Backup-Utility/issues/20))
  - PHP Style Guide -> 6. Comments -> Ambiguous Numbers.

- 3a672e4 Decrease line length ([#20](https://github.com/dynamiccookies/Simple-Backup-Utility/issues/20))
  - Following the PHP Style Guide, each PHP line has been decreased to 80 characters or less unless it is a text string.
  - Created new `print_columns()` function to call from the HTML code to make it more readable.
  - Created new `show_message()` function to call from the HTML code to make it more readable.

- 353e3ba Update `get_latest_release_tag()` function
  - Renamed function dropping '_tag'.
  - Added `$repo` parameter to remove hardcoded value from function.
  - Added hardcoded repo value to `$latest_version` variable initialization call.

- 3495524 Update `$message_color` variable
  - Rather than defaulting color to red, defaulted to blank string.
  - Created `$red` variable with hex value.
  - Added `$message_color = $red;` line to every place `$message_text` was being set with an error.
  - Alphabetized order of `$message_color` before `$message_text` wherever they're set.

- 7738700 Update `compare_versions()` function
  - Moved `$release_url` variable and value out of function to section with other variable initializations to remove hardcoded value from function.

- ac5177b Updated code spacing and comment
  - Added a divider comment to show the end of the primary PHP code and the beginning of the primary HTML code.
  - Added `\n` and extra blank lines to the HTML code after PHP tags to better format the resulting HTML.

- ea08b62 Updated embedded PHP in HTML section
  - Added a couple variables to store the results of `htmlspecialchars()` results to make the code more readable.
  - Updated the `foreach` from using a colon to use curly brackets.

- 6fcce98 Fix bug and HTML formatting
  - Re-add space that was accidentally removed in BETA version message text.
  - Add `\n` to end of message text to better format resulting HTML.

- a7e0d3b Alphabetize `$_POST[]` checks
  - There are 3 checks for POST values of 'backup', 'delete', and 'update'. They were ordered as delete, update, backup, but are now alphabetized.

- d2b8176 Clarify JavaScript comments
  - Updated JavaScript comment text to add clarification around the two different timeouts.

- 84436de Adjust spacing
  - Added spaces to align JavaScript variables
  - Added blank line to better format resulting HTML

- bc2ea3c Replaced `$current_dir` variable with `__DIR__`
  - Moved `$backup_folders` variable to top of script in alphabetical order
  - Replaced `$current_dir` variable with `__DIR__` constant

- ba8036b Conditionally show message CSS & JavaScript ([#43](https://github.com/dynamiccookies/Simple-Backup-Utility/issues/43))
  - Added `if ($message_text)` wrapper around `.message` CSS block
  - Added `if ($message_text)` wrapper around `messageDiv` timeout
  - Removed redundant `if (messageDiv)` test

- 9136008 Conditionally show Existing Backups JavaScript ([#43](https://github.com/dynamiccookies/Simple-Backup-Utility/issues/43))
  - Added `if (!empty($backup_folders))` wrapper for `confirmDelete()`, `convertToLocalTime()`, and `window.addEventListener()` to change date format
  - Moved `.message` timeout JavaScript to be after

- b1b1cf5 Disconnect combined CSS for `button.backup` & `.message`
  - Copied the shared lines of CSS between `button.backup` and `.message` into the `.message` block since it may not always exit ([#43](https://github.com/dynamiccookies/Simple-Backup-Utility/issues/43))

- a29dd86 Conditionally show Existing Backups CSS ([#43](https://github.com/dynamiccookies/Simple-Backup-Utility/issues/43))
  - Moved conditional CSS blocks to bottom of CSS section
  - Moved `.fade-out` into conditional message wrapper and added comment
  - Added `if (!empty($backup_folders))` wrapper to Existing Backups CSS

- 8549e6d Fix bug when `$backup_folders` moved
  - `$backup_folders` needs to be set after the folder backup or delete occurs to ensure the page doesn't require another refresh

- c1c2cca Fix undefined variable bug
  - Missed renaming `$folder` to `$delete_folder`
